### PR TITLE
Fixing nginx recipe order

### DIFF
--- a/recipes/nginx.rb
+++ b/recipes/nginx.rb
@@ -19,17 +19,16 @@
 
 include_recipe "zabbix-custom-checks::default"
 
-template "#{node.zabbix.agent.include_dir}/nginx.conf" do
-	source "nginx/nginx.conf.erb"
-	mode "644"
-	notifies :restart, "service[zabbix_agentd]"
-end	
-
 template "#{node.zabbix.external_dir}/nginx_status.sh" do
 	source "nginx/nginx_status.sh.erb"
 	mode "755"
 end
 
+template "#{node.zabbix.agent.include_dir}/nginx.conf" do
+	source "nginx/nginx.conf.erb"
+	mode "644"
+	notifies :restart, "service[zabbix_agentd]", :delayed
+end
 
 include_recipe "nginx"
 	


### PR DESCRIPTION
Changed the order of the script and the Zabbix agent config to make sure that the script is available when the Zabbix clients tries to access it when it's running. Else it can break with multiple log messages in the agent log like this:

```
sh: 1: /opt/zabbix/externalscripts/nginx_status.sh: not found
sh: 1: /opt/zabbix/externalscripts/nginx_status.sh: not found
```

Also made the agent restart delayed, since it's not useful to restart it multiple times if it comes to that during the chef-client run because of other recipes too.
